### PR TITLE
엔티티 객체 동등성 비교 수정

### DIFF
--- a/src/main/java/com/example/boardproject/domain/Article.java
+++ b/src/main/java/com/example/boardproject/domain/Article.java
@@ -1,14 +1,8 @@
 package com.example.boardproject.domain;
 
 import lombok.*;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -53,12 +47,12 @@ public class Article extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return getId() != null && getId().equals(article.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(getId());
     }
 
     private Article(UserAccount userAccount, String title, String content, String hashtag) {

--- a/src/main/java/com/example/boardproject/domain/ArticleComment.java
+++ b/src/main/java/com/example/boardproject/domain/ArticleComment.java
@@ -1,14 +1,8 @@
 package com.example.boardproject.domain;
 
 import lombok.*;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 /**
@@ -52,11 +46,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return getId() != null && getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/example/boardproject/domain/UserAccount.java
+++ b/src/main/java/com/example/boardproject/domain/UserAccount.java
@@ -59,11 +59,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return getId() != null && getId().equals(that.getId());
+        return getUserId() != null && getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId());
+        return Objects.hash(getUserId());
     }
 }

--- a/src/main/java/com/example/boardproject/domain/UserAccount.java
+++ b/src/main/java/com/example/boardproject/domain/UserAccount.java
@@ -59,11 +59,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.userId);
+        return getId() != null && getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(getId());
     }
 }


### PR DESCRIPTION
* 엔티티 객체가 프록시 객체일때 `getter`를 통해 접근해야 정상적인 값 비교를 할 수 있기 떄문에 수정
This closes #50 