### PR TITLE
보안강화 - 환경변수 적용

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,9 +15,9 @@ logging:
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/board
-    username: song
-    password: 1234
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
 
   jpa:
     defer-datasource-initialization: true


### PR DESCRIPTION
`application.yaml` 파일에 DB 관련 민감정보를 환경변수를 활용하여 깃헙 코드에 노출되지 않도록 하였다. 하지만 이미 이전 커밋에 변수에 대한 내용이 드러나 있어서 이전 커밋 로그를 추적하면 그 값을 찾아낼수 있어서 소용없지만 지금이라도 변경함.

This closes #74 