### PR TITLE
data rest 에 userId 검색 api 기능 추가

### DIFF
--- a/src/main/java/com/example/boardproject/repository/UserAccountRepository.java
+++ b/src/main/java/com/example/boardproject/repository/UserAccountRepository.java
@@ -1,8 +1,13 @@
 package com.example.boardproject.repository;
 
+import com.example.boardproject.domain.QUserAccount;
 import com.example.boardproject.domain.UserAccount;
 import com.example.boardproject.domain.projection.UserAccountProjection;
+import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import java.util.Optional;
@@ -12,6 +17,17 @@ import java.util.Optional;
  * @since 1.0
  */
 @RepositoryRestResource(excerptProjection = UserAccountProjection.class)
-public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long>
+        ,QuerydslPredicateExecutor<UserAccount>
+        ,QuerydslBinderCustomizer<QUserAccount> {
+
     Optional<UserAccount> findByUserId(String userId);
+
+    @Override
+    default void customize(QuerydslBindings bindings, QUserAccount root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.userId);
+        bindings.bind(root.userId).first(StringExpression::eq);
+
+    }
 }


### PR DESCRIPTION
`Querydsl Web Support` 를 활용하여 parameter 로 userId를 받아서 api 검색을 가능하게끔 구현

This closes #85 